### PR TITLE
chore: automate API docs update

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,28 @@
+name: Update API docs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: sudo apt-get update && sudo apt-get install -y python3-requests
+      - run: bash scripts/update_docs.sh
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet; then
+            echo "No changes to commit"
+          else
+            git add docs/ENDPOINTS.md docs/japer_api_collection.json docs/UPDATE_LOG.md
+            git commit -m 'chore: update API docs'
+            git push
+          fi

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -40,3 +40,4 @@
 | decrypt | POST | `/v1/x/decrypt` | [link](https://developer.japer.io#218739dc-adcf-4111-98bf-a6b850a90e4b) |
 | lookup | POST | `/v1/x/lookup` | [link](https://developer.japer.io#e38e344b-ca93-41a9-992c-5647dcb78fbd) |
 | execute | POST | `/v1/x/execute` | [link](https://developer.japer.io#f8f0f1d2-f8c9-4284-b641-b680ce64cfd4) |
+

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -1,0 +1,3 @@
+# Update Log
+
+Updated: 2025-09-10 04:47:31 UTC

--- a/scripts/generate_endpoints_md.py
+++ b/scripts/generate_endpoints_md.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate Markdown table of API endpoints from Postman collection."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COLLECTION_PATH = REPO_ROOT / "docs" / "japer_api_collection.json"
+OUTPUT_PATH = REPO_ROOT / "docs" / "ENDPOINTS.md"
+
+CATEGORY_MAP = {
+    "Ping": "Service Status",
+    "Devices": "Device Management",
+    "Validations": "Customer Validation",
+    "Encryptions": "Data Encryption",
+    "Decryptions": "Data Decryption",
+}
+
+CATEGORY_ORDER = [
+    "Service Status",
+    "Device Management",
+    "Customer Validation",
+    "Data Encryption",
+    "Data Decryption",
+]
+
+
+def traverse(items, lineage):
+    for item in items:
+        name = item.get("name", "")
+        if "request" in item:
+            yield lineage + [name], item
+        if "item" in item:
+            yield from traverse(item["item"], lineage + [name])
+
+
+def main() -> int:
+    with COLLECTION_PATH.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    endpoints: dict[str, list[tuple[str, str, str, str]]] = {v: [] for v in CATEGORY_MAP.values()}
+
+    for path, item in traverse(data.get("item", []), []):
+        if not path:
+            continue
+        top = path[0]
+        category = CATEGORY_MAP.get(top)
+        if not category:
+            continue
+        req = item["request"]
+        method = req.get("method", "")
+        raw_url = req.get("url", "")
+        parsed = urlparse(raw_url)
+        path_str = parsed.path
+        name = item.get("name", "")
+        postman_id = item.get("_postman_id", "")
+        link = f"https://developer.japer.io#{postman_id}" if postman_id else ""
+        endpoints[category].append((name, method, path_str, link))
+
+    with OUTPUT_PATH.open("w", encoding="utf-8") as f:
+        f.write("# API Endpoints\n\n")
+        for category in CATEGORY_ORDER:
+            rows = endpoints.get(category)
+            if not rows:
+                continue
+            f.write(f"## {category}\n\n")
+            f.write("| Endpoint | Method | Path | Docs |\n")
+            f.write("| --- | --- | --- | --- |\n")
+            for name, method, path_str, link in rows:
+                f.write(f"| {name} | {method} | `{path_str}` | [link]({link}) |\n")
+            f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+python3 "$SCRIPT_DIR/fetch_api_docs.py"
+python3 "$SCRIPT_DIR/generate_endpoints_md.py"
+
+LOG_FILE="$REPO_ROOT/docs/UPDATE_LOG.md"
+mkdir -p "$(dirname "$LOG_FILE")"
+if [ ! -f "$LOG_FILE" ]; then
+  echo "# Update Log" > "$LOG_FILE"
+  echo >> "$LOG_FILE"
+fi
+
+date -u +'Updated: %Y-%m-%d %H:%M:%S UTC' >> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- generate API endpoint markdown from Postman collection
- add nightly workflow to refresh API documentation
- log API docs update times

## Testing
- `bash scripts/update_docs.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c102360f288325abfb84dc09b61026