### PR TITLE
docs: cross-link API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![AI](https://img.shields.io/badge/Assisted-Development-2b2bff?logo=openai&logoColor=white)](https://www.japer.technology)
 
 ### Developer Resources
-- [https://developer.japer.io](https://developer.japer.io) - hosts API docs and integration guides
-- [API Endpoints](docs/ENDPOINTS.md) - table of endpoints
+- [https://developer.japer.io](https://developer.japer.io) - hosts API docs and integration guides. See [API Endpoints](docs/ENDPOINTS.md) for a table of endpoints.
 
 ### Installation
 

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md)
+
 # API Endpoints
 
 ## Service Status


### PR DESCRIPTION
## Summary
- link to API endpoints from developer resources
- add README backlink in endpoints guide

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c272ce1ce483259f8eef8074760dde