### PR TITLE
Automate API docs refresh

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,7 +2,7 @@ name: Update API docs
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # nightly at midnight UTC
   workflow_dispatch:
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: sudo apt-get update && sudo apt-get install -y python3-requests
+      - run: pip install -r requirements.txt
       - run: bash scripts/update_docs.sh
       - name: Commit changes
         run: |

--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1,5 +1,3 @@
-[Back to README](../README.md)
-
 # API Endpoints
 
 ## Service Status

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -1,3 +1,4 @@
 # Update Log
 
 Updated: 2025-09-10 04:47:31 UTC
+Updated: 2025-09-11 07:11:09 UTC

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/.."
 
-python3 "$SCRIPT_DIR/fetch_api_docs.py"
-python3 "$SCRIPT_DIR/generate_endpoints_md.py"
+python "$SCRIPT_DIR/fetch_api_docs.py"
+python "$SCRIPT_DIR/generate_endpoints_md.py"
 
 LOG_FILE="$REPO_ROOT/docs/UPDATE_LOG.md"
 mkdir -p "$(dirname "$LOG_FILE")"


### PR DESCRIPTION
## Summary
- refresh API docs via update_docs.sh script that pulls latest collection and regenerates markdown
- run nightly GitHub Action to keep API docs current
- record each refresh time in docs/UPDATE_LOG.md

## Testing
- `pytest`
- `bash scripts/update_docs.sh`

------
https://chatgpt.com/codex/tasks/task_b_68c275abf2708325b3264d28397ff195